### PR TITLE
Oauth implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puma', '~> 3.11'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'faraday', '>= 0.15.4'
 gem 'pry-byebug'
+gem 'composite_primary_keys', '=11.1.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     coderay (1.1.2)
+    composite_primary_keys (11.1.0)
+      activerecord (~> 5.2.1)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
     erubi (1.8.0)
@@ -145,6 +147,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  composite_primary_keys (= 11.1.0)
   faraday (>= 0.15.4)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/auths_controller.rb
+++ b/app/controllers/auths_controller.rb
@@ -1,0 +1,10 @@
+class AuthsController < ApplicationController
+
+  def index
+    params.require([:code, :state])
+    code = params[:code]
+    state = params[:state]
+    render json: state
+  end
+
+end

--- a/app/controllers/auths_controller.rb
+++ b/app/controllers/auths_controller.rb
@@ -1,10 +1,44 @@
 class AuthsController < ApplicationController
 
   def index
+
+    # First we get the code and state params that Slack sends back to use during the OAuth flow
     params.require([:code, :state])
-    code = params[:code]
-    state = params[:state]
-    render json: state
+    oauth_code = params[:code]
+    oauth_state = params[:state]
+
+    # Next match a request back to the Slack oauth.access API to get a token
+    conn = Faraday.new(:url => 'https://slack.com/api/') do |c|
+      c.request  :url_encoded
+      #c.response :logger                  # log requests to STDOUT
+      #c.response :json                  # form response as JSON (otherwise it will be a string)
+      c.adapter  Faraday.default_adapter  # make requests with Net::HTTP
+    end
+
+    body = {
+      client_id: Rails.configuration.app_client_id,
+      client_secret: Rails.configuration.app_client_secret,
+      code: oauth_code,
+      redirect_uri: "#{Util.get_app_url}/auth"
+    }
+
+    response = conn.post do |req|
+      req.url 'oauth.access'
+      req.body = body
+    end
+
+    # Great, we got a response back, let's make it is valid
+    if response.status != 200
+      raise ActionController::RoutingError.new('Received error from Slack')
+    end
+
+    # Now parse the response and store the details
+    body = JSON.parse(response.body)
+    Auth.find_or_create_by(user_id: body['user_id'], team_id: body['team_id'], access_token: body['access_token'], scope: body['scope'], bot_user_id: body['bot']['bot_user_id'], bot_access_token: body['bot']['bot_access_token'])
+
+    # Redirect the user back to Slack, going right to the bot DM
+    redirect_to "https://slack.com/app_redirect?app=#{Rails.configuration.app_id}&team=#{body['team_id']}", :status => 302
+
   end
 
 end

--- a/app/controllers/auths_controller.rb
+++ b/app/controllers/auths_controller.rb
@@ -29,7 +29,7 @@ class AuthsController < ApplicationController
 
     # Great, we got a response back, let's make it is valid
     if response.status != 200
-      raise ActionController::RoutingError.new('Received error from Slack')
+      raise ActionController::RoutingError.new("Error! Received a #{response.status} during OAuth.")
     end
 
     # Now parse the response and store the details

--- a/app/controllers/provisions_controller.rb
+++ b/app/controllers/provisions_controller.rb
@@ -1,0 +1,24 @@
+class ProvisionsController < ApplicationController
+
+  SCOPE = 'commands,bot,chat:write:bot'
+
+  def index
+
+    app_uri = Util.get_app_url
+    state = 'lacroix' # TODO this should be generated with some uniqueness based on the user
+    oauth_url = "https://slack.com/oauth/authorize?scope=#{SCOPE}&client_id=#{Rails.configuration.app_client_id}&redirect_uri=#{Util.get_app_url}/auth&state=#{state}"
+    redirect_to oauth_url, :status => 302
+
+  end
+
+  private
+
+  # If we want to render an "Add to Slack" button instead of a "direct url" then use
+  # render html: add_to_slack_button.html_safe
+  # The HEREDOC below has the HTML code to generate the button
+  def add_to_slack_button
+    <<~HEREDOC
+      <a href="https://slack.com/oauth/authorize?scope=#{SCOPE}&client_id=#{Rails.configuration.app_client_id}&redirect_uri=#{Util.get_app_url}/auth&state=lacroix"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
+    HEREDOC
+  end
+end

--- a/app/controllers/provisions_controller.rb
+++ b/app/controllers/provisions_controller.rb
@@ -3,12 +3,10 @@ class ProvisionsController < ApplicationController
   SCOPE = 'commands,bot,chat:write:bot'
 
   def index
-
     app_uri = Util.get_app_url
     state = 'lacroix' # TODO this should be generated with some uniqueness based on the user
     oauth_url = "https://slack.com/oauth/authorize?scope=#{SCOPE}&client_id=#{Rails.configuration.app_client_id}&redirect_uri=#{Util.get_app_url}/auth&state=#{state}"
     redirect_to oauth_url, :status => 302
-
   end
 
   private

--- a/app/lib/util.rb
+++ b/app/lib/util.rb
@@ -1,0 +1,7 @@
+class Util
+
+  def self.get_app_url()
+    Rails.env.development? ? 'http://localhost:3000' : 'https://lacroix-mclacroixface.herokuapp.com'
+  end
+
+end

--- a/app/models/auth.rb
+++ b/app/models/auth.rb
@@ -1,0 +1,2 @@
+class Auth < ApplicationRecord
+end

--- a/app/views/provisions/index.html.erb
+++ b/app/views/provisions/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Hi</h1>
-sldkfjsldfj

--- a/app/views/provisions/index.html.erb
+++ b/app/views/provisions/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Hi</h1>
+sldkfjsldfj

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,9 @@ module Lacroix
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Slack App client ID and secret for oauth
+    config.app_client_id = '4559011355.513032508945'
+    config.app_client_secret = ENV["SLACK_LACROIX_BOT_CLIENT_SECRET"]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,6 @@ module Lacroix
     # Slack App client ID and secret for oauth
     config.app_client_id = '4559011355.513032508945'
     config.app_client_secret = ENV["SLACK_LACROIX_BOT_CLIENT_SECRET"]
+    config.app_id = 'AF30YEYTT'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
 
   resources :intakes, only: [:create]
   post '/message' => 'messages#index'
+  get '/provision' => 'provisions#index'
+  get '/auth' => 'auths#index'
 end

--- a/db/migrate/20181231232230_create_auths.rb
+++ b/db/migrate/20181231232230_create_auths.rb
@@ -1,0 +1,16 @@
+class CreateAuths < ActiveRecord::Migration[5.2]
+  def change
+    create_table :auths, primary_key: %i[user_id team_id] do |t|
+      t.string :user_id
+      t.string :team_id
+      t.string :access_token
+      t.string :scope
+      t.string :bot_user_id
+      t.string :bot_access_token
+
+      t.timestamps
+
+      t.index :team_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_30_012401) do
+ActiveRecord::Schema.define(version: 2018_12_31_232230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "auths", primary_key: ["user_id", "team_id"], force: :cascade do |t|
+    t.string "user_id", null: false
+    t.string "team_id", null: false
+    t.string "access_token"
+    t.string "scope"
+    t.string "bot_user_id"
+    t.string "bot_access_token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_auths_on_team_id"
+  end
 
   create_table "flavors", force: :cascade do |t|
     t.string "name"


### PR DESCRIPTION
**Before this**
-------

- We had no way to provision a Slack App using OAuth

**What this PR does**
-------

Adds an OAuth implementation to our bot following https://api.slack.com/docs/oauth

1. Adds a `/provision` route that will initiate the Slack OAuth 2.0 dance to install the App on an workspace
2. Adds a `/auth` route and DB migration to store the auth information on our side.
3. Adds three `config` variables to track our App config information. One of these is via an environment variable.

**Testing**
-------

- No unit test coverage, yet
- Manually tested this in dev and ensure it (1) stores the Auth information correctly and (2) redirects the user back to Slack

**Risk**
-------

Low. Not actually using this yet